### PR TITLE
Use https to download submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "immer"]
 	path = immer
-	url = git@github.com:arximboldi/immer.git
+	url = https://github.com/arximboldi/immer


### PR DESCRIPTION
When using jpm to install this, I was getting publickey errors when it tried to download the immer submodule because I don't have any ssh keys configured globally (I set them on a per-repo basis). This pull request changes the submodule to use https instead, which should fix this error.